### PR TITLE
#6: Combine identical line items in basket

### DIFF
--- a/shop.js
+++ b/shop.js
@@ -37,11 +37,17 @@ function renderBasket() {
     if (cartButtonsRow) cartButtonsRow.style.display = "none";
     return;
   }
-  basket.forEach((product) => {
+  // Group items by product and count quantities
+  const groupedItems = basket.reduce((acc, product) => {
+    acc[product] = (acc[product] || 0) + 1;
+    return acc;
+  }, {});
+  // Render each unique product with its quantity
+  Object.entries(groupedItems).forEach(([product, quantity]) => {
     const item = PRODUCTS[product];
     if (item) {
       const li = document.createElement("li");
-      li.innerHTML = `<span class='basket-emoji'>${item.emoji}</span> <span>${item.name}</span>`;
+      li.innerHTML = `<span class='basket-emoji'>${item.emoji}</span> <span>${quantity}x ${item.name}</span>`;
       basketList.appendChild(li);
     }
   });


### PR DESCRIPTION
Group identical products and display with quantity (e.g., "3x Apple") instead of showing each unit as a separate line item.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Combines duplicate basket items into a single line with a quantity for clearer cart display.
> 
> - Replaces per-item rendering with grouping via `reduce` and renders `"{quantity}x {name}"` for each product in `renderBasket`
> - Retains empty-state message and `cart-buttons-row` visibility behavior
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 72314d79ce17c9d348ff58e4bc12ceaca2648709. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->