### PR TITLE
#6: Combine identical line items in basket

### DIFF
--- a/shop.js
+++ b/shop.js
@@ -37,14 +37,22 @@ function renderBasket() {
     if (cartButtonsRow) cartButtonsRow.style.display = "none";
     return;
   }
-  basket.forEach((product) => {
+
+  // Group items by product and count quantities
+  const groupedItems = basket.reduce((acc, product) => {
+    acc[product] = (acc[product] || 0) + 1;
+    return acc;
+  }, {});
+
+  Object.entries(groupedItems).forEach(([product, quantity]) => {
     const item = PRODUCTS[product];
     if (item) {
       const li = document.createElement("li");
-      li.innerHTML = `<span class='basket-emoji'>${item.emoji}</span> <span>${item.name}</span>`;
+      li.innerHTML = `<span class='basket-emoji'>${item.emoji}</span> <span>${quantity}x ${item.name}</span>`;
       basketList.appendChild(li);
     }
   });
+
   if (cartButtonsRow) cartButtonsRow.style.display = "flex";
 }
 


### PR DESCRIPTION
Group identical products in the shopping basket and display quantities (e.g., "3x Apple" instead of listing "Apple" three times).